### PR TITLE
Remove u8 from list of supported data types

### DIFF
--- a/1/storing-a-value.md
+++ b/1/storing-a-value.md
@@ -19,7 +19,7 @@ contract! {
 
 ## Supported Types
 
-Contract storage like `storage::Value<T>` is allowed to be generic over types that are encodable and decodable with [Parity Codec](https://github.com/paritytech/parity-codec) which includes the most common types such as `bool`, `u{16,32,64,128}`, `i{8,16,32,64,128}`, `String`, tuples, and arrays.  Note that `u8` is not currently supported.
+Contract storage like `storage::Value<T>` is allowed to be generic over types that are encodable and decodable with [Parity Codec](https://github.com/paritytech/parity-codec) which includes the most common types such as `bool`, `u{16,32,64,128}`, `i{8,16,32,64,128}`, `String`, tuples, and arrays.  Note that `u8` is [not currently supported](https://github.com/paritytech/parity-codec/issues/47) in `parity_codec`.
 
 ink! also supports Substrate specific types like `AccountId`, `Balance`, and `Hash`. To use some of these non-primitive types, we have to import them from `ink_core::env`. Here is an example of how you would store an `AccountId` and `Balance`:
 

--- a/1/storing-a-value.md
+++ b/1/storing-a-value.md
@@ -19,7 +19,7 @@ contract! {
 
 ## Supported Types
 
-Contract storage like `storage::Value<T>` is allowed to be generic over types that are encodable and decodable with [Parity Codec](https://github.com/paritytech/parity-codec) which includes the most common types such as `bool`, `u{8,16,32,64,128}`, `i{8,16,32,64,128}`, `String`, tuples, and arrays.
+Contract storage like `storage::Value<T>` is allowed to be generic over types that are encodable and decodable with [Parity Codec](https://github.com/paritytech/parity-codec) which includes the most common types such as `bool`, `u{16,32,64,128}`, `i{8,16,32,64,128}`, `String`, tuples, and arrays.  Note that `u8` is not currently supported.
 
 ink! also supports Substrate specific types like `AccountId`, `Balance`, and `Hash`. To use some of these non-primitive types, we have to import them from `ink_core::env`. Here is an example of how you would store an `AccountId` and `Balance`:
 


### PR DESCRIPTION
`u8` is currently not supported for storage (explanation here: https://github.com/paritytech/parity-codec/issues/47).  This PR removes it from the list of supported data types mentioned in 1/storing-a-value.md and adds a note indicating that it is not included.

